### PR TITLE
Exit proxy immediately upon attempted closing of LM

### DIFF
--- a/src/Objects/Proxy.java
+++ b/src/Objects/Proxy.java
@@ -46,7 +46,15 @@ public class Proxy {
     }
 
     public void run() {
-        List<String> args = new ArrayList<>(Arrays.asList(new String[]{path + mitm, "-p", getPort() + "", "-d", "freegamez.ga", "-s", "mf.svc.nhl.com,playback.svcs.mlb.com,mlb-ws-mf.media.mlb.com"}));
+        List<String> args = new ArrayList<>(
+            Arrays.asList(
+                path + mitm,
+                "-p",
+                getPort() + "",
+                "-d", "freegamez.ga",
+                "-s", "mf.svc.nhl.com,playback.svcs.mlb.com,mlb-ws-mf.media.mlb.com"
+            )
+        );
         ProcessBuilder pb = new ProcessBuilder(args).inheritIO().redirectErrorStream(true);
         try {
             p = pb.start();

--- a/src/lazyman/MainGUI.java
+++ b/src/lazyman/MainGUI.java
@@ -890,7 +890,7 @@ public final class MainGUI extends javax.swing.JFrame {
     private void formWindowClosing(java.awt.event.WindowEvent evt) {//GEN-FIRST:event_formWindowClosing
         SwingWorker<Void, Void> w = waiting();
         w.execute();
-        InfiniteBar ub = new InfiniteBar(null, true, "Waiting for stream(s) to close then exiting...");
+        InfiniteBar ub = new InfiniteBar(null, true, "Waiting for proxy to close then exiting...");
         ub.setLocationRelativeTo(null);
         ub.setVisible(true);
     }//GEN-LAST:event_formWindowClosing
@@ -997,14 +997,10 @@ public final class MainGUI extends javax.swing.JFrame {
         worker = new SwingWorker<Void, Void>() {
             @Override
             protected Void doInBackground() throws Exception {
-                while (streamCnt > 0) {
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ex) {
-                        p.kill();
-                    }
+                while (p.isRunning()) {
+                    p.kill();
                 }
-                p.kill();
+
                 System.exit(0);
                 return null;
             }


### PR DESCRIPTION
Addresses #34.

When attempting to exit LM, it kills the proxy then exits. This is instead of the current behaviour of waiting for the stream to exit, then killing the proxy and exiting LM.

I am unsure of the actual purpose of the proxy so it's very likely this solution won't be the correct one, but it does prevent the ghost proxies from running when force quitting. If this isn't a feasible solution, I am happy to discuss and get back with something different.