### PR TITLE
Add HTTP scheme to proxy URL to work around Streamlink/urllib bug

### DIFF
--- a/src/Objects/Streamlink.java
+++ b/src/Objects/Streamlink.java
@@ -42,7 +42,7 @@ public class Streamlink {
         String ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36";
         ProcessBuilder pb;
 
-        List<String> args = new ArrayList<>(Arrays.asList(new String[]{location, getURLFormat(gwi.getUrl(), gwi.getQuality().equals("best")), gwi.getQuality(), "--http-header", "User-Agent=" + ua, "--hls-segment-threads=4", "--https-proxy", "127.0.0.1:" + port}));
+        List<String> args = new ArrayList<>(Arrays.asList(new String[]{location, getURLFormat(gwi.getUrl(), gwi.getQuality().equals("best")), gwi.getQuality(), "--http-header", "User-Agent=" + ua, "--hls-segment-threads=4", "--https-proxy", "http://127.0.0.1:" + port}));
 
         if (record) {
             String saveLoc = Props.getSaveStreamLoc() + File.separator + gwi.getDate();


### PR DESCRIPTION
Apologies for the edit frenzy on this - my understanding of the issue evolved several times after submitting the original change.

On an Arch Linux system with streamlink 2.1.1 installed, I observe the following when attempting to view a stream:
```
-----
Streamlink starting...
[cli][info] Found matching plugin hls for URL hlsvariant://<censored> name_key=bitrate verify=False
[cli][info] Available streams: 670k (worst), 1000k, 1450k, 2140k, 2900k, 4100k, 6600k (best)
[cli][info] Opening stream: 6600k (hls)
[stream.hls][error] Failed to create decryptor: Unable to open URL: https://mf.svc.nhl.com/ws/media/mf/v2.3/key/silk/mediaid/2026695171/kid/70407944 (Proxy URL had no scheme, should start with http:// or https://)
[cli][error] Try 1/1: Could not open stream <HLSStream('<censored>', 'http://hlslive-akc.med2.med.nhl.com/hdnts=exp=1622515261~acl=/*~id=nhlGatewayId:9959474~data=2026695171~hmac=ce48db07c4391527e421480ef19278ce64f727357cad1efbc49a9cda298e25af/0982711f2eeb6fb73012af9cad37a185/ls03/nhl/2021/05/30/NHL_GAME_VIDEO_TBLCAR_M2_NATIONAL_20210530_1622298961363/master_wired60.m3u8')> (No data returned from stream)
error: Could not open stream <HLSStream('<censored>', 'http://hlslive-akc.med2.med.nhl.com/hdnts=exp=1622515261~acl=/*~id=nhlGatewayId:9959474~data=2026695171~hmac=ce48db07c4391527e421480ef19278ce64f727357cad1efbc49a9cda298e25af/0982711f2eeb6fb73012af9cad37a185/ls03/nhl/2021/05/30/NHL_GAME_VIDEO_TBLCAR_M2_NATIONAL_20210530_1622298961363/master_wired60.m3u8')>, tried 1 times, exiting
[cli][info] Closing currently open stream...

Streamlink done
```

There appears to be a bug between streamlink and urllib wherein if streamlink is called with `--https-proxy 127.0.0.1:8050`, urllib's `urlparse()` function fails to parse this string properly and streamlink never adds `http://` onto the front of the url in their `update_scheme()` function. When this (improper) url is eventually fed into urllib3 it results in a `ProxySchemeUnknown` excpeption.

This PR updates the arguments with which LazyMan calls Streamlink such that instead of (e.g.) `--https-proxy 127.0.0.1:8050`, it is called as `--https-proxy http://127.0.0.1:8050`. This change allows LM to work properly on the aforementioned Arch Linux system and ought to be fully backwards compatible (though I have not thoroughly tested this).